### PR TITLE
Options to speed up searching for goodput

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -315,7 +315,9 @@ def main(argv):
     warmup_qps = qps_range[0]
     warmup_requests, num_requests = get_requests_for_qps(
       requests_list, warmup_qps, num_requests=FLAGS.num_warmup_requests)
+    client.bail_on_error = False
     _ = client.run(warmup_requests, num_requests, warmup_qps)
+    client.bail_on_error = FLAGS.bail_on_error
     if FLAGS.num_warmup_delay_seconds:
       tf.logging.info("Waiting for %d seconds after warmup", FLAGS.num_warmup_delay_seconds)
       time.sleep(FLAGS.num_warmup_delay_seconds)

--- a/benchmark.py
+++ b/benchmark.py
@@ -115,6 +115,8 @@ tf.app.flags.DEFINE_string("default_int_type", "",
                            "Default type to use for integer values.")
 tf.app.flags.DEFINE_string("default_float_type", "",
                            "Default type to use for fractional values.")
+tf.app.flags.DEFINE_bool("busy_sleep", False,
+                         "Use busy sleep instead of time.sleep().")
 
 FLAGS = tf.app.flags.FLAGS
 
@@ -282,7 +284,8 @@ def main(argv):
                         FLAGS.distribution, FLAGS.input_name,
                         FLAGS.default_int_type,
                         FLAGS.default_float_type, http_headers, grpc_metadata,
-                        get_grpc_compression(), FLAGS.request_timeout)
+                        get_grpc_compression(), FLAGS.request_timeout,
+                        FLAGS.busy_sleep)
 
   tf.logging.info("Loading data")
   requests_list = client.get_requests(request_format, request_path,

--- a/clients/base_client.py
+++ b/clients/base_client.py
@@ -34,7 +34,7 @@ class BaseClient(metaclass=abc.ABCMeta):
     self._grpc_compression = grpc_compression
     self._request_timeout = request_timeout
     self._busy_sleep = busy_sleep
-    self._bail_on_error = bail_on_error
+    self.bail_on_error = bail_on_error
     self.bail_event = multiprocessing.Event()
 
   @abc.abstractmethod

--- a/clients/base_client.py
+++ b/clients/base_client.py
@@ -3,6 +3,7 @@
 import abc
 import base64
 import time
+import multiprocessing
 from enum import Enum
 import tensorflow.compat.v1 as tf
 
@@ -18,7 +19,7 @@ class BaseClient(metaclass=abc.ABCMeta):
   def __init__(self, host, port, model_name, model_version, signature_name,
                distribution, input_name, default_int_type, default_float_type,
                http_headers, grpc_metadata, grpc_compression, request_timeout,
-               busy_sleep):
+               busy_sleep, bail_on_error):
     self._host = host
     self._port = port
     self._model_name = model_name
@@ -33,6 +34,8 @@ class BaseClient(metaclass=abc.ABCMeta):
     self._grpc_compression = grpc_compression
     self._request_timeout = request_timeout
     self._busy_sleep = busy_sleep
+    self._bail_on_error = bail_on_error
+    self.bail_event = multiprocessing.Event()
 
   @abc.abstractmethod
   def get_requests_from_tfrecord(self, path, count, batch_size):
@@ -64,6 +67,16 @@ class BaseClient(metaclass=abc.ABCMeta):
         inputs = sess.run(next)
         rows.append(inputs)
     return rows
+
+  def sleep(self, seconds: float) -> None:
+    if seconds < 0:
+      raise ValueError("Sleep seconds can't be negative.", seconds)
+    if self._busy_sleep:
+      wakeup = time.time() + seconds
+      while time.time() < wakeup:
+        time.sleep(0.0)
+    else:
+      time.sleep(seconds)
 
   def sleep(self, seconds: float) -> None:
     if seconds < 0:

--- a/clients/base_grpc_client.py
+++ b/clients/base_grpc_client.py
@@ -129,7 +129,7 @@ class BaseGrpcClient(clients.base_client.BaseClient, metaclass=abc.ABCMeta):
     previous_worker_start = start_time
     error_details = set()
     for request in requests:
-      if self._bail_on_error and self.bail_event.is_set():
+      if self.bail_on_error and self.bail_event.is_set():
         break
 
       interval = dist.next()

--- a/clients/base_grpc_client.py
+++ b/clients/base_grpc_client.py
@@ -146,7 +146,7 @@ class BaseGrpcClient(clients.base_client.BaseClient, metaclass=abc.ABCMeta):
       # send requests at a constant rate and adjust for the time it took to send previous request
       pause = interval - (time.time() - previous_worker_start)
       if pause > 0:
-        time.sleep(pause)
+        self.sleep(pause)
       else:
         missed_delay = (100 *
                         ((time.time() - previous_worker_start) - interval) /

--- a/clients/base_rest_client.py
+++ b/clients/base_rest_client.py
@@ -77,7 +77,7 @@ class BaseRestClient(clients.base_client.BaseClient, metaclass=abc.ABCMeta):
       # send requests at a constant rate and adjust for the time it took to send previous request
       pause = interval - (time.time() - previous_worker_start)
       if pause > 0:
-        time.sleep(pause)
+        self.sleep(pause)
       else:
         missed_delay = (100 *
                         ((time.time() - previous_worker_start) - interval) /

--- a/clients/tensorflow_serving_sync_grpc.py
+++ b/clients/tensorflow_serving_sync_grpc.py
@@ -80,7 +80,7 @@ class TensorflowServingSyncGrpc(
       # send requests at a constant rate and adjust for the time it took to send previous request
       pause = interval - (time.time() - previous_worker_start)
       if pause > 0:
-        time.sleep(pause)
+        self.sleep(pause)
       else:
         missed_delay = (100 *
                         ((time.time() - previous_worker_start) - interval) /

--- a/clients/vertex_gapic.py
+++ b/clients/vertex_gapic.py
@@ -146,7 +146,7 @@ class VertexGapic(clients.base_client.BaseClient):
       # send requests at a constant rate and adjust for the time it took to send previous request
       pause = interval - (time.time() - previous_worker_start)
       if pause > 0:
-        time.sleep(pause)
+        self.sleep(pause)
       else:
         missed_delay = (100 *
                         ((time.time() - previous_worker_start) - interval) /


### PR DESCRIPTION
I added the following options to speed up searching for goodput:

* `--bail_on_error`: Stop sending more requests for the current QPS if any error occurs
* `--goodput_search_p99_ms`: Run with high-to-low QPS. Skip lower QPS if all requests succeeded and p99 is less than the given value for the current QPS.

Also added a `--busy_sleep` options to use busy spin for sleeping instead of using `time.sleep`. It marginally decreases the chance that a worker missed the time to send out a request.